### PR TITLE
Ajustando o security group

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,33 +19,31 @@ resource "random_string" "suffix" {
   upper   = false
 }
 
-# Criar a instância EC2
 resource "aws_instance" "ec2_instance" {
-  ami           = "ami-0f2ad13ff5f6b6f7c" # AMI Ubuntu 22.04 aws 
+  ami           = "ami-0ac80df6eff0e70b5" # Certifique-se de que a AMI seja válida
   instance_type = "t2.nano"
-  key_name      = aws_key_pair.deployer.key_name # Chave para acesso SSH
+  key_name      = aws_key_pair.deployer.key_name
+  security_groups = [aws_security_group.allow_ssh.name] # Associa o Security Group
 
-  tags = {
-    Name = "terraform-example"
-  }
-
-  # Provisionamento remoto via SSH para instalar Docker
   provisioner "remote-exec" {
     inline = [
       "sudo apt-get update",
       "sudo apt-get install -y docker.io",
-      "sudo usermod -aG docker ubuntu",  # Adicionar o usuário ubuntu ao grupo docker
+      "sudo usermod -aG docker ubuntu",
       "sudo systemctl start docker",
       "sudo systemctl enable docker"
     ]
 
-    # Conexão SSH para a instância EC2
     connection {
       type        = "ssh"
-      user        = "ubuntu"  # Usuário correto para a AMI do Ubuntu
+      user        = "ubuntu"
       private_key = tls_private_key.example.private_key_pem
       host        = self.public_ip
     }
+  }
+
+  tags = {
+    Name = "terraform-example"
   }
 }
 

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,0 +1,23 @@
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound traffic"
+  vpc_id      = "vpc-0859a6c0d7f723e53" # vpc id da sua conta
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # Qualquer IP pode acessar
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_ssh"
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Adjust the security group configuration by adding a new security group resource to allow SSH access and associating it with the EC2 instance. Update the AMI for the EC2 instance to ensure it is valid.

Enhancements:
- Update the AMI used for the EC2 instance to ensure it is valid.
- Associate a security group with the EC2 instance to manage SSH access.

Deployment:
- Add a new security group resource to allow SSH inbound traffic from any IP.