### PR TITLE
Ajustando o ssh

### DIFF
--- a/.github/workflows/main.ymal
+++ b/.github/workflows/main.ymal
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      
+
 jobs:
   terraform:
     runs-on: ubuntu-latest
@@ -44,8 +44,7 @@ jobs:
 
       # Step 7: Fazer o deploy na instância EC2 via SSH
       - name: Deploy to EC2 via SSH
-        env:
-          EC2_PUBLIC_IP=$(terraform output -raw instance_ip)
         run: |
+          EC2_PUBLIC_IP=$(terraform output -raw instance_ip)
           echo "Deploying to EC2 instance with IP: $EC2_PUBLIC_IP"
-          ssh -o StrictHostKeyChecking=no ec2-user@$EC2_PUBLIC_IP 'bash -s' < ./scripts/deploy.sh
+          ssh -o StrictHostKeyChecking=no ubuntu@$EC2_PUBLIC_IP 'bash -s' < ./scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,5 +12,4 @@ fi
 # Exibe o IP público obtido
 echo "Deploying to EC2 instance with IP: $EC2_PUBLIC_IP"
 
-# Executa o deploy via SSH
-ssh -o StrictHostKeyChecking=no ubuntu@$EC2_PUBLIC_IP 'bash -s' < ./scripts/deploy.sh
+# Exec

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "allow_ssh" {
-  name        = "allow_sshss"
+  name        = "allow_ssh3"
   description = "Allow SSH inbound traffic"
   vpc_id      = "vpc-0859a6c0d7f723e53" # vpc id da sua conta
 


### PR DESCRIPTION
## Summary by Sourcery

Remove SSH command execution from the deploy script and rename the security group in Terraform configuration.

Enhancements:
- Rename security group from 'allow_sshss' to 'allow_ssh3' in Terraform configuration.

Deployment:
- Remove SSH command execution from deploy script.