### PR TITLE
ajustando o arquivo que puxa

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,31 +55,21 @@ resource "aws_security_group" "allow_ssh" {
 
 # Criar Instância EC2
 resource "aws_instance" "ec2_instance" {
-  ami              = "ami-0ac80df6eff0e70b5" # Certifique-se de que a AMI seja válida
+  ami              = "ami-0ac80df6eff0e70b5"
   instance_type    = "t2.nano"
   key_name         = aws_key_pair.deployer.key_name
   security_groups  = [aws_security_group.allow_ssh.name]
   associate_public_ip_address = true
 
-  # Provisionamento para instalar Docker, copiar código, e rodar a aplicação
   provisioner "remote-exec" {
     inline = [
-      "sudo apt-get update",
-      "sudo apt-get install -y docker.io",  # Instalar Docker
-      "sudo usermod -aG docker ubuntu",  # Adicionar o usuário ao grupo Docker
-      "sudo systemctl start docker",  # Iniciar o serviço Docker
-      "sudo systemctl enable docker",  # Habilitar Docker no boot
-      "mkdir -p /home/ubuntu/app",  # Criar o diretório para o código da aplicação
-      # Copiar o código da aplicação para a instância
-      "echo '${file("src/requirements.txt")}' > /home/ubuntu/app/requirements.txt",  # Copiar requirements.txt
-      "echo '${file("src/app.py")}' > /home/ubuntu/app/app.py",  # Copiar app.py
-      "echo '${file("src/Dockerfile")}' > /home/ubuntu/app/Dockerfile",  # Copiar Dockerfile
-      # Construir a imagem Docker e rodar a aplicação
-      "cd /home/ubuntu/app",
-      "sudo docker build -t my-python-app .",  # Construir a imagem Docker
-      "sudo docker run -d -p 5000:5000 my-python-app"  # Rodar o container
+      "echo '${template_file.requirements_txt.rendered}' > /home/ubuntu/app/requirements.txt",
+      "echo '${template_file.app_py.rendered}' > /home/ubuntu/app/app.py",
+      "echo '${template_file.dockerfile.rendered}' > /home/ubuntu/app/Dockerfile",
+      "sudo docker build -t my-python-app .",
+      "sudo docker run -d -p 5000:5000 my-python-app"
     ]
-
+    
     connection {
       type        = "ssh"
       user        = "ubuntu"
@@ -93,7 +83,15 @@ resource "aws_instance" "ec2_instance" {
   }
 }
 
-# Output para exibir o IP público da instância
-output "instance_ip" {
-  value = aws_instance.ec2_instance.public_ip
+# Adicionar templates
+data "template_file" "requirements_txt" {
+  template = file("${path.module}/src/requirements.txt")
+}
+
+data "template_file" "app_py" {
+  template = file("${path.module}/src/app.py")
+}
+
+data "template_file" "dockerfile" {
+  template = file("${path.module}/src/Dockerfile")
 }

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,5 +1,5 @@
-resource "aws_security_group" "allow_ssh16" {
-  name        = "allow_ssh16"
+resource "aws_security_group" "allow_ssh17" {
+  name        = "allow_ssh17"
   description = "Allow SSH inbound traffic"
   vpc_id      = "vpc-0859a6c0d7f723e53" # vpc id da sua conta
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Terraform configuration for EC2 instance provisioning by using template files for application code, and update the security group name to 'allow_ssh17'.

Enhancements:
- Refactor EC2 instance provisioning to use template files for application code instead of inline file copying.

Deployment:
- Update security group name from 'allow_ssh16' to 'allow_ssh17'.