### PR TITLE
ajustando o arquivo que puxa

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,9 +63,9 @@ resource "aws_instance" "ec2_instance" {
 
   provisioner "remote-exec" {
     inline = [
-      "echo '${template_file.requirements_txt.rendered}' > /home/ubuntu/app/requirements.txt",
-      "echo '${template_file.app_py.rendered}' > /home/ubuntu/app/app.py",
-      "echo '${template_file.dockerfile.rendered}' > /home/ubuntu/app/Dockerfile",
+      "echo '${file("src/requirements.txt")}' > /home/ubuntu/app/requirements.txt",
+      "echo '${file("src/app.py")}' > /home/ubuntu/app/app.py",
+      "echo '${file("src/Dockerfile")}' > /home/ubuntu/app/Dockerfile",
       "sudo docker build -t my-python-app .",
       "sudo docker run -d -p 5000:5000 my-python-app"
     ]

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,5 +1,5 @@
-resource "aws_security_group" "allow_ssh17" {
-  name        = "allow_ssh17"
+resource "aws_security_group" "allow_ssh20" {
+  name        = "allow_ssh20"
   description = "Allow SSH inbound traffic"
   vpc_id      = "vpc-0859a6c0d7f723e53" # vpc id da sua conta
 


### PR DESCRIPTION
## Summary by Sourcery

Update Terraform configuration to use local file references for application deployment and change the security group name for SSH access.

Enhancements:
- Update Terraform script to use local file references instead of template file rendering for application files.

Deployment:
- Modify security group name from 'allow_ssh17' to 'allow_ssh20' in Terraform configuration.