### PR TITLE
ajustando caminho

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,21 +32,21 @@ resource "aws_s3_bucket" "my_bucket" {
 resource "aws_s3_bucket_object" "requirements_txt" {
   bucket = aws_s3_bucket.my_bucket.bucket
   key    = "requirements.txt"
-  source = "./requirements.txt"  
+  source = "./src/requirements.txt"  
   acl    = "private"
 }
 
 resource "aws_s3_bucket_object" "app_py" {
   bucket = aws_s3_bucket.my_bucket.bucket
   key    = "app.py"
-  source = "./app.py"  
+  source = "./src/app.py"  
   acl    = "private"
 }
 
 resource "aws_s3_bucket_object" "dockerfile" {
   bucket = aws_s3_bucket.my_bucket.bucket
   key    = "Dockerfile"
-  source = "./Dockerfile"  
+  source = "./src/app.py"  
   acl    = "private"
 }
 

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,5 +1,5 @@
-resource "aws_security_group" "allow_ssh24" {
-  name        = "allow_ssh24"
+resource "aws_security_group" "allow_ssh25" {
+  name        = "allow_ssh25"
   description = "Allow SSH inbound traffic"
   vpc_id      = "vpc-0859a6c0d7f723e53" # vpc id da sua conta
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust the source paths for S3 bucket objects and rename the AWS security group to reflect updated configurations.

Deployment:
- Update the source paths for S3 bucket objects to reflect their new locations in the 'src' directory.
- Rename the AWS security group from 'allow_ssh24' to 'allow_ssh25'.