### PR TITLE
ajustando esteira

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,51 +36,21 @@ jobs:
         working-directory: ./terraform
         run: terraform apply -auto-approve
 
-      # Opção 1: Usar `terraform output` diretamente (mais simples e recomendada)
-      - name: Get EC2 Public IP with terraform output
+      # Step 6: Obter o IP público da instância EC2 diretamente após o apply
+      - name: Get EC2 Public IP
         id: ec2_ip
-        working-directory: ./terraform
         run: |
           EC2_IP=$(terraform output -raw instance_ip)
           if [ -z "$EC2_IP" ]; then
             echo "Erro: Não foi possível encontrar o IP público da instância EC2"
             exit 1
           fi
-          echo "EC2_IP=${EC2_IP}"
-          echo "EC2_IP=$EC2_IP" >> $GITHUB_ENV
-
-      # Opção 2: Verificar e processar o arquivo JSON `state.json` (usando `terraform show`)
-      - name: Get EC2 Public IP using state.json (optional)
-        if: ${{ failure() }}
-        working-directory: ./terraform
-        run: |
-          terraform show -json > state.json
-          
-          # Verificar se o arquivo JSON foi gerado corretamente
-          if [ -s state.json ]; then
-            echo "Arquivo state.json gerado com sucesso"
-          else
-            echo "Erro: Arquivo state.json está vazio ou não foi gerado corretamente"
-            exit 1
-          fi
-
-          # Remover linhas inválidas do início do arquivo (se necessário)
-          sed -i '/^[^{}]/d' state.json
-
-          # Exibir o conteúdo para debug
-          cat state.json
-
-          # Processar o JSON e extrair o IP
-          EC2_IP=$(cat state.json | jq -r '.values.root_module.resources[] | select(.type=="aws_instance") | .values.public_ip')
-          if [ -z "$EC2_IP" ]; then
-            echo "Erro: Não foi possível encontrar o IP público da instância EC2"
-            exit 1
-          fi
-          echo "EC2_IP=${EC2_IP}"
-          echo "EC2_IP=$EC2_IP" >> $GITHUB_ENV
+          echo "EC2_IP=$EC2_IP" >> $GITHUB_ENV  # Definindo como variável de ambiente
 
       # Step 7: Deploy Python app na instância EC2
       - name: Deploy Python app on EC2
+        env:
+          EC2_IP: ${{ env.EC2_IP }}  # Usando variável de ambiente diretamente
         run: |
           if [ -z "$EC2_IP" ]; then
             echo "EC2 IP não encontrado!"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Simplify the process of obtaining the EC2 public IP by removing the optional step of using 'terraform show' and processing 'state.json', and instead directly using 'terraform output'.