### PR TITLE
ajustando

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,9 +36,8 @@ jobs:
         working-directory: ./terraform
         run: terraform apply -auto-approve
 
-      # Step 6: Obter o IP público da instância EC2 diretamente após o apply
+      # Step 6: Obter o IP público da instância EC2 e salvar em um arquivo
       - name: Get EC2 Public IP
-        id: ec2_ip
         working-directory: ./terraform
         run: |
           EC2_IP=$(terraform output -raw instance_ip | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}')
@@ -47,13 +46,10 @@ jobs:
             echo "Erro: Não foi possível encontrar o IP público da instância EC2"
             exit 1
           fi
-          echo "::set-output name=EC2_IP::$EC2_IP"  # Armazena o IP como uma saída do step
-          echo "EC2_IP=$EC2_IP" >> $GITHUB_ENV  # Também salva no ambiente para uso posterior
+          echo "EC2_IP=$EC2_IP" >> $GITHUB_ENV  # Armazena o IP no arquivo de ambiente
 
       # Step 7: Deploy Python app on EC2
       - name: Deploy Python app on EC2
-        env:
-          EC2_IP: ${{ steps.ec2_ip.outputs.EC2_IP }}  # Referencia o IP do step anterior
         run: |
           ssh -o StrictHostKeyChecking=no -i "${{ secrets.EC2_PRIVATE_KEY }}" ubuntu@${{ env.EC2_IP }} << 'EOF'
             echo "Iniciando deploy..."


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify the GitHub Actions workflow to save the EC2 public IP directly to the environment file instead of using step outputs.