### PR TITLE
chave ssh

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: Terraform EC2 Deploy
+name: Deploy EC2 Application
 
 on:
   push:
@@ -6,62 +6,48 @@ on:
       - main
 
 jobs:
-  terraform:
+  deploy:
     runs-on: ubuntu-latest
-
     steps:
-      # Step 1: Checkout o repositório
-      - name: Checkout code
-        uses: actions/checkout@v2
+    - name: Check out code
+      uses: actions/checkout@v2
 
-      # Step 2: Configurar o AWS CLI para acessar sua conta
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+    - name: Set up AWS CLI
+      run: |
+        curl "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
+        aws --version
 
-      # Step 3: Instalar o Terraform
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
 
-      # Step 4: Inicializar o Terraform
-      - name: Terraform Init
-        working-directory: ./terraform
-        run: terraform init
+    - name: Create EC2 instance
+      run: |
+        aws ec2 run-instances \
+          --image-id ami-0ac80df6eff0e70b5 \  # Substitua pela ID correta da AMI
+          --count 1 \
+          --instance-type t2.micro \
+          --key-name minha-chave-ec2 \
+          --security-group-ids sg-xxxxxxxx \  # Substitua pelo ID do seu Security Group
+          --subnet-id subnet-xxxxxxxx \  # Substitua pelo ID da sua Subnet
+          --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=MinhaInstanciaEC2}]'
 
-      # Step 5: Rodar o Terraform Apply para criar a instância EC2
-      - name: Terraform Apply
-        working-directory: ./terraform
-        run: terraform apply -auto-approve
+    - name: Get EC2 instance public IP
+      id: get-ip
+      run: |
+        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --output text)
+        PUBLIC_IP=$(aws ec2 describe-instances --instance-id $INSTANCE_ID --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+        echo "PUBLIC_IP=$PUBLIC_IP" >> $GITHUB_ENV
 
-      # Step 6: Obter o IP público da instância EC2 e passar como output
-      - name: Get EC2 Public IP
-        id: ec2_ip
-        working-directory: ./terraform
-        run: |
-          EC2_IP=$(terraform output -raw instance_ip | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}')
-          echo "EC2 IP: $EC2_IP"
-          if [ -z "$EC2_IP" ]; then
-            echo "Erro: Não foi possível encontrar o IP público da instância EC2"
-            exit 1
-          fi
-          echo "::set-output name=ip::${EC2_IP}"  # Define o IP como output da etapa
-
-      # Passo para configurar a chave privada no ambiente
-      - name: Set up SSH private key
-        run: |
-          echo "${{ secrets.EC2_PRIVATE_KEY }}" > private_key.pem
-          chmod 600 private_key.pem
-
-      # Passo para fazer o deploy no EC2
-      - name: Deploy Python app on EC2
-        run: |
-          echo "Conectando no EC2 com o IP: ${{ steps.ec2_ip.outputs.ip }}"
-        
-          # Conectar via SSH usando a chave privada
-          ssh -o StrictHostKeyChecking=no -i private_key.pem ubuntu@${{ steps.ec2_ip.outputs.ip }} << 'EOF'
+    - name: Deploy to EC2 instance
+      run: |
+        # Conectando via SSH e executando os comandos de deploy
+        ssh -i minha-chave-ec2.pem ubuntu@$PUBLIC_IP << 'EOF'
             echo "Iniciando deploy..."
             sudo apt-get update
             sudo apt-get install -y docker.io
@@ -70,8 +56,4 @@ jobs:
             sudo docker build -t my-python-app .
             sudo docker run -d -p 5000:5000 my-python-app
             echo "Deploy concluído"
-          EOF
-
-      # Limpeza da chave privada
-      - name: Clean up private key
-        run: rm -f private_key.pem
+        EOF


### PR DESCRIPTION
## Summary by Sourcery

Update the CI workflow to use AWS CLI for EC2 instance management instead of Terraform, simplifying the deployment process.

CI:
- Rename the GitHub Actions workflow from 'Terraform EC2 Deploy' to 'Deploy EC2 Application'.
- Refactor the CI workflow to replace Terraform-based EC2 instance creation with AWS CLI commands.